### PR TITLE
:sparkles: Added age_ratings section to game details

### DIFF
--- a/backend/games/fields.py
+++ b/backend/games/fields.py
@@ -1,5 +1,8 @@
 _game_fields = [
     'age_ratings',
+    'age_ratings.category',
+    'age_ratings.rating',
+    'age_ratings.rating_cover_url',
     'cover.image_id',
     'first_release_date',
     'genres.name',
@@ -14,6 +17,7 @@ _game_fields = [
     'summary',
     'time_to_beat.normally',
     'themes.name',
+    'videos'
 ]
 
 _search_fields = [

--- a/frontend/src/modules/game/components/details/index.js
+++ b/frontend/src/modules/game/components/details/index.js
@@ -19,6 +19,9 @@ const Details = ({ game }) => {
         )
       ]
     : [];
+    const lookup={
+      1:'Three',2:'Seven',3:'Twelve',4:'Sixteen',5:'Eighteen',6:'RP',7:'EC',8:'E',9:'E10',10:'T',11:'M',12:'AO',"01":'ESRB',"02":'PEGI'
+    }
 
   return (
     <Tab
@@ -92,15 +95,27 @@ const Details = ({ game }) => {
                       })}
                   </Grid.Column>
                 </Grid.Row>
-                {game.age_ratings !== undefined &&(
+                <Grid.Row>
+                  <Grid.Column width={8}>
+                    <h3>
+                      <span>Age Ratings</span>
+                    </h3>
+                  </Grid.Column>
+                  <Grid.Column width={8} className="details">
+                      {game.age_ratings !== undefined && game.age_ratings.map(a =>{
+                      return <Label key={a.category}>{lookup[0+""+a.category]+" "+lookup[a.rating]}</Label>
+                    })}
+                  </Grid.Column>
+                </Grid.Row>
+                {game.videos !== undefined &&(
                   <Grid.Row>
                     <Grid.Column width={8}>
                       <h3>
-                        <span>Age Ratings</span>
+                        <span>Videos</span>
                       </h3>
                     </Grid.Column>
                     <Grid.Column width={8} className="details">
-                      <Label>{game.age_ratings}</Label>
+                      <Label>{game.videos}</Label>
                     </Grid.Column>
                   </Grid.Row>
                 )}


### PR DESCRIPTION
**Fields.py**
- age_ratings field is used to verify if an age rating exists for a specific game/components/details/index
 - age_ratings returns an array of age ratings that usually consists of both the PEGI and ESRB ratings
 - age_ratings.category returns an ENUM that helps us decide whether the rating is from ESRB (returns 1) or PEGI(returns 2)
 - age_ratings.rating returns an ENUM(between 1-12) that helps us decide the rating corresponding to the category returned above
 - also added videos field as it will be used to get the trailer video


**Index.js**
 - the lookup object contains the ENUM mapings for age_ratings.rating and age_ratings.category
 - using the game.age_ratings we check if the age_ratings is present for a particular game or not.
 - If present we display the age ratings given by ESRB and PEGI