### PR TITLE
:construction: Add similar games section to game details page

### DIFF
--- a/backend/games/fields.py
+++ b/backend/games/fields.py
@@ -19,7 +19,11 @@ _game_fields = [
     'themes.name',
     'videos.name',
     'videos',
-    'videos.video_id'
+    'videos.video_id',
+    'similar_games',
+    'similar_games.cover.image_id',
+    'similar_games.slug',
+    'similar_games.name'
 ]
 
 _search_fields = [

--- a/frontend/src/modules/game/components/index.js
+++ b/frontend/src/modules/game/components/index.js
@@ -8,3 +8,4 @@ export { default as TextLoader } from "./loaders/TextLoader";
 export { default as QuickStats } from "./quick-stats";
 export { default as Screenshots } from "./screenshots";
 export { default as Video } from "./video";
+export { default as Similar } from "./similar-games";

--- a/frontend/src/modules/game/components/similar-games/Similar_game.js
+++ b/frontend/src/modules/game/components/similar-games/Similar_game.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Image } from "semantic-ui-react";
+import "./styles.css"
+
+
+export const Cover = (({id ,size, imageID, slug, key, name})=>{
+     const src=`https://images.igdb.com/igdb/image/upload/t_screenshot_${size}/${imageID}.jpg`
+
+    return(
+     <a key={id} className="cover-wrapper" href={`/games/${slug}`} target="_blank">
+         <Image src={src} rounded alt={slug} className="cover" size="big"/>
+         <div key={key} class="cover-overlay">
+             <strong>{name}</strong>
+         </div>
+     </a>   
+    )
+})

--- a/frontend/src/modules/game/components/similar-games/index.js
+++ b/frontend/src/modules/game/components/similar-games/index.js
@@ -1,0 +1,28 @@
+import React from "react";
+import {Cover} from "./Similar_game";
+import {Header} from "semantic-ui-react";
+import "./styles.css";
+
+
+
+const Similar = ({similar_games,isLoading})=>{
+    return(<div className="similar">
+        <Header className="white">Similar Games</Header>
+        <section className="sec">
+        {!isLoading ? (
+            <React.Fragment>
+                {similar_games.map((g,i)=>{
+                    return (<Cover size="big" imageID={g.cover.image_id} slug={g.slug} key={i} id={g} name={g.name}/>)
+                })}
+            </React.Fragment>
+        ):(
+            <React.Fragment>
+                {[...Array(6)].map((_, i) => (
+                    <div key={i} className="placeholder" />
+                ))}
+            </React.Fragment>
+        )}
+    </section></div>)
+}
+
+export default Similar;

--- a/frontend/src/modules/game/components/similar-games/styles.css
+++ b/frontend/src/modules/game/components/similar-games/styles.css
@@ -1,0 +1,75 @@
+.similar .ui.header.white {
+  color: #fff;
+  margin: 0;
+}
+.sec {
+    text-align: center;
+  }
+  
+  .similar .sec .cover-wrapper {
+    margin: 1rem 0.5rem 0 0.5rem;
+    width: 135px;
+    height: 192px;
+    display: inline-flex;
+    overflow: hidden;
+    box-shadow: 0 0 0 1px rgb(48, 56, 64);
+    border-radius: 0.3125rem;
+    cursor: pointer;
+  }
+  
+  .similar .sec .cover-wrapper:last-child,
+  .similar .placeholder:last-child {
+    margin: 1rem 0 0 0.5rem;
+  }
+  
+  .similar .sec .cover-wrapper:hover .cover-overlay {
+    opacity: 1;
+  }
+  
+  .similar .sec .cover {
+    width: 100%;
+    height: 100%;
+    border-radius: 0.3125rem;
+  }
+  
+  .similar .sec .cover-overlay {
+    position: absolute;
+    opacity: 0;
+    flex-shrink: 0;
+    display: block;
+    z-index: 2;
+    width: 135px;
+    height: 192px;
+    transition: opacity 0.2s;
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 0.3125rem;
+  }
+  
+  .cover-overlay > strong {
+    color: #fff;
+    text-shadow: 0 0 7px rgba(0, 0, 0, 0.45);
+    padding: 0 0.325rem;
+    height: 100%;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+  }
+  
+  .similar .sec .placeholder {
+    display: inline-block;
+    width: 135px;
+    height: 192px;
+    margin: 1rem 0.5rem 0 0.5rem;
+    background: #0c0e10;
+    box-shadow: 0 0 0 1px rgb(48, 56, 64);
+    border-radius: 0.3125rem;
+  }
+  
+  @media only screen and (max-width: 767px) and (min-width: 320px) {
+    .similar .sec .cover-wrapper,
+    .similar .sec .placeholder {
+      width: 90px;
+      height: 128px;
+    }
+  }
+  

--- a/frontend/src/modules/game/index.js
+++ b/frontend/src/modules/game/index.js
@@ -12,7 +12,8 @@ import {
   TextLoader,
   ActionsLoader,
   Screenshots,
-  Video
+  Video,
+  Similar
 } from "./components/";
 import "./styles.css";
 import ShowMoreText from 'react-show-more-text';
@@ -181,6 +182,14 @@ export default class Game extends React.Component {
               <Grid.Column width={4} />
               <Grid.Column width={9}>
                 {!isLoading && <Screenshots screenshots={game.screenshots} />}
+              </Grid.Column>
+              <Grid.Column width={3} />
+            </Grid.Row>
+            <Grid.Row>
+              {/* the following empty columns are used as offset */}
+              <Grid.Column width={4} />
+              <Grid.Column width={9}>
+                {!isLoading && <Similar similar_games={game.similar_games} isLoading={isLoading} />}
               </Grid.Column>
               <Grid.Column width={3} />
             </Grid.Row>


### PR DESCRIPTION
 - :sparkles: :construction:  imported fields required for  displaying similar games in `backend\games\fields.py`
 - :sparkles: added a new component called similar-games
 - :construction: built similar games display based on the popular games module from the landing page
 - :poop: known bug where the game cover in similar games displays in landscape orientation for somereason attaching screenshots in fix #121

Co-authored-by: Amrithnath <arjun.amrith@gmail.com>
Co-authored-by: arjunamrith <amrith@tydy.it>